### PR TITLE
bugfix/accurics_remediation_35840197917687344 - Auto Generated Pull Request From Accurics

### DIFF
--- a/db.tf
+++ b/db.tf
@@ -25,4 +25,5 @@ resource "aws_db_instance" "db" {
   tags = {
     Name = "${local.prefix.value}-db"
   }
+  storage_encrypted = true
 }


### PR DESCRIPTION
Storage encryption can be enabled for AWS RDS Instances by using the 'Enable Encryption' option while creating the database instances. Amazon RDS encrypted DB instances use the industry standard AES-256 encryption algorithm to encrypt the data on the server that hosts Amazon RDS DB instances.